### PR TITLE
Make function definition namings consistent

### DIFF
--- a/functions/create_draft/definition.ts
+++ b/functions/create_draft/definition.ts
@@ -8,7 +8,7 @@ export const CREATE_DRAFT_FUNCTION_CALLBACK_ID = "create_draft";
  * More on defining functions here:
  * https://api.slack.com/future/functions/custom
  */
-export const CreateDraftFunction = DefineFunction({
+export const CreateDraftFunctionDefinition = DefineFunction({
   callback_id: CREATE_DRAFT_FUNCTION_CALLBACK_ID,
   title: "Create a draft announcement",
   description:

--- a/functions/create_draft/interaction_handler.ts
+++ b/functions/create_draft/interaction_handler.ts
@@ -3,7 +3,7 @@ import {
   ViewSubmissionHandler,
 } from "deno-slack-sdk/functions/interactivity/types.ts";
 
-import { CreateDraftFunctionDefinition } from "./definition.ts";
+import { CreateDraftFunctionDefinition as CreateDraftFunction } from "./definition.ts";
 import {
   buildConfirmSendModal,
   buildDraftBlocks,
@@ -22,7 +22,7 @@ import DraftDatastore from "../../datastores/drafts.ts";
  */
 
 export const openDraftEditView: BlockActionHandler<
-  typeof CreateDraftFunctionDefinition.definition
+  typeof CreateDraftFunction.definition
 > = async ({ body, action, client }) => {
   if (action.selected_option.value == "edit_message_overflow") {
     const id = action.block_id;
@@ -76,7 +76,7 @@ export const openDraftEditView: BlockActionHandler<
 };
 
 export const saveDraftEditSubmission: ViewSubmissionHandler<
-  typeof CreateDraftFunctionDefinition.definition
+  typeof CreateDraftFunction.definition
 > = async (
   { inputs, view, client },
 ) => {
@@ -124,7 +124,7 @@ export const saveDraftEditSubmission: ViewSubmissionHandler<
 };
 
 export const confirmAnnouncementForSend: BlockActionHandler<
-  typeof CreateDraftFunctionDefinition.definition
+  typeof CreateDraftFunction.definition
 > = async (
   { inputs, body, action, client },
 ) => {
@@ -139,7 +139,7 @@ export const confirmAnnouncementForSend: BlockActionHandler<
 };
 
 export const prepareSendAnnouncement: ViewSubmissionHandler<
-  typeof CreateDraftFunctionDefinition.definition
+  typeof CreateDraftFunction.definition
 > = async ({ body, view, client }) => {
   // Get the datastore draft ID from the modal's private metadata
   const { id } = JSON.parse(view.private_metadata || "");

--- a/functions/create_draft/interaction_handler.ts
+++ b/functions/create_draft/interaction_handler.ts
@@ -3,7 +3,7 @@ import {
   ViewSubmissionHandler,
 } from "deno-slack-sdk/functions/interactivity/types.ts";
 
-import { CreateDraftFunction } from "./definition.ts";
+import { CreateDraftFunctionDefinition } from "./definition.ts";
 import {
   buildConfirmSendModal,
   buildDraftBlocks,
@@ -22,7 +22,7 @@ import DraftDatastore from "../../datastores/drafts.ts";
  */
 
 export const openDraftEditView: BlockActionHandler<
-  typeof CreateDraftFunction.definition
+  typeof CreateDraftFunctionDefinition.definition
 > = async ({ body, action, client }) => {
   if (action.selected_option.value == "edit_message_overflow") {
     const id = action.block_id;
@@ -76,7 +76,7 @@ export const openDraftEditView: BlockActionHandler<
 };
 
 export const saveDraftEditSubmission: ViewSubmissionHandler<
-  typeof CreateDraftFunction.definition
+  typeof CreateDraftFunctionDefinition.definition
 > = async (
   { inputs, view, client },
 ) => {
@@ -124,7 +124,7 @@ export const saveDraftEditSubmission: ViewSubmissionHandler<
 };
 
 export const confirmAnnouncementForSend: BlockActionHandler<
-  typeof CreateDraftFunction.definition
+  typeof CreateDraftFunctionDefinition.definition
 > = async (
   { inputs, body, action, client },
 ) => {
@@ -139,7 +139,7 @@ export const confirmAnnouncementForSend: BlockActionHandler<
 };
 
 export const prepareSendAnnouncement: ViewSubmissionHandler<
-  typeof CreateDraftFunction.definition
+  typeof CreateDraftFunctionDefinition.definition
 > = async ({ body, view, client }) => {
   // Get the datastore draft ID from the modal's private metadata
   const { id } = JSON.parse(view.private_metadata || "");

--- a/functions/create_draft/mod.ts
+++ b/functions/create_draft/mod.ts
@@ -1,6 +1,6 @@
 import { SlackFunction } from "deno-slack-sdk/mod.ts";
 
-import { CreateDraftFunction } from "./definition.ts";
+import { CreateDraftFunctionDefinition } from "./definition.ts";
 import { buildDraftBlocks } from "./blocks.ts";
 import {
   confirmAnnouncementForSend,
@@ -13,14 +13,14 @@ import { ChatPostMessageParams, DraftStatus } from "./types.ts";
 import DraftDatastore from "../../datastores/drafts.ts";
 
 /**
- * This is the handling code for the CreateDraftFunction. It will:
+ * This is the handling code for the CreateDraftFunctionDefinition. It will:
  * 1. Create a new datastore record with the draft
  * 2. Build a Block Kit message with the draft and send it to input channel
  * 3. Update the draft record with the successful sent drafts timestamp
  * 4. Pause function completion until user interaction
  */
 export default SlackFunction(
-  CreateDraftFunction,
+  CreateDraftFunctionDefinition,
   async ({ inputs, client }) => {
     const draftId = crypto.randomUUID();
 

--- a/functions/post_summary/definition.ts
+++ b/functions/post_summary/definition.ts
@@ -9,7 +9,7 @@ export const POST_ANNOUNCEMENT_FUNCTION_CALLBACK_ID = "post_summary";
  * More on custom function definition here:
  * https://api.slack.com/future/functions/custom
  */
-export const PostSummaryFunction = DefineFunction({
+export const PostSummaryFunctionDefinition = DefineFunction({
   callback_id: POST_ANNOUNCEMENT_FUNCTION_CALLBACK_ID,
   title: "Post announcement summary",
   description: "Post a summary of all sent announcements ",

--- a/functions/post_summary/mod.ts
+++ b/functions/post_summary/mod.ts
@@ -1,16 +1,16 @@
 import { SlackFunction } from "deno-slack-sdk/mod.ts";
 
 import { buildSummaryBlocks } from "./blocks.ts";
-import { PostSummaryFunction } from "./definition.ts";
+import { PostSummaryFunctionDefinition } from "./definition.ts";
 
 /**
- * This is the handling code for PostSummaryFunction. It will:
+ * This is the handling code for PostSummaryFunctionDefinition. It will:
  * 1. Post a message in thread to the draft announcement message
  * with a summary of announcement's sent
  * 2. Complete this function with either required outputs or an error
  */
 export default SlackFunction(
-  PostSummaryFunction,
+  PostSummaryFunctionDefinition,
   async ({ inputs, client }) => {
     const blocks = buildSummaryBlocks(inputs.announcements);
 

--- a/functions/send_announcement/definition.ts
+++ b/functions/send_announcement/definition.ts
@@ -9,7 +9,7 @@ export const SEND_ANNOUNCEMENT_FUNCTION_CALLBACK_ID = "send_announcement";
  * More on custom function definition here:
  * https://api.slack.com/future/functions/custom
  */
-export const prepareSendAnnouncementFunction = DefineFunction({
+export const PrepareSendAnnouncementFunctionDefinition = DefineFunction({
   callback_id: SEND_ANNOUNCEMENT_FUNCTION_CALLBACK_ID,
   title: "Send an announcement",
   description: "Sends a message to one or more channels",

--- a/functions/send_announcement/mod.ts
+++ b/functions/send_announcement/mod.ts
@@ -1,7 +1,7 @@
 import { SlackFunction } from "deno-slack-sdk/mod.ts";
 import { SlackAPIClient } from "deno-slack-api/types.ts";
 
-import { prepareSendAnnouncementFunction } from "./definition.ts";
+import { PrepareSendAnnouncementFunctionDefinition } from "./definition.ts";
 import { buildAnnouncementBlocks, buildSentBlocks } from "./blocks.ts";
 import { AnnouncementType } from "../post_summary/types.ts";
 import { ChatPostMessageParams, DraftStatus } from "../create_draft/types.ts";
@@ -10,13 +10,13 @@ import DraftDatastore from "../../datastores/drafts.ts";
 import AnnouncementsDatastore from "../../datastores/announcements.ts";
 
 /**
- * This is the handling code for prepareSendAnnouncementFunction. It will:
+ * This is the handling code for PrepareSendAnnouncementFunctionDefinition. It will:
  * 1. Send announcement to each channel supplied
  * 2. Updates the status of the announcement in the
  */
 
 export default SlackFunction(
-  prepareSendAnnouncementFunction,
+  PrepareSendAnnouncementFunctionDefinition,
   async ({ inputs, client }) => {
     // Array to gather chat.postMessage responses
     // deno-lint-ignore no-explicit-any

--- a/workflows/create_announcement.ts
+++ b/workflows/create_announcement.ts
@@ -1,7 +1,7 @@
 import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
-import { CreateDraftFunction } from "../functions/create_draft/definition.ts";
-import { PostSummaryFunction } from "../functions/post_summary/definition.ts";
-import { prepareSendAnnouncementFunction } from "../functions/send_announcement/definition.ts";
+import { CreateDraftFunctionDefinition } from "../functions/create_draft/definition.ts";
+import { PostSummaryFunctionDefinition } from "../functions/post_summary/definition.ts";
+import { PrepareSendAnnouncementFunctionDefinition } from "../functions/send_announcement/definition.ts";
 
 /**
  * A workflow is a set of steps that are executed in order
@@ -79,18 +79,21 @@ const formStep = CreateAnnouncementWorkflow
 // Step 2: Create a draft announcement
 // This step uses a custom function published by this app
 // https://api.slack.com/future/functions/custom
-const draftStep = CreateAnnouncementWorkflow.addStep(CreateDraftFunction, {
-  created_by: CreateAnnouncementWorkflow.inputs.created_by,
-  message: formStep.outputs.fields.message,
-  channels: formStep.outputs.fields.channels,
-  channel: formStep.outputs.fields.channel,
-  icon: formStep.outputs.fields.icon,
-  username: formStep.outputs.fields.username,
-});
+const draftStep = CreateAnnouncementWorkflow.addStep(
+  CreateDraftFunctionDefinition,
+  {
+    created_by: CreateAnnouncementWorkflow.inputs.created_by,
+    message: formStep.outputs.fields.message,
+    channels: formStep.outputs.fields.channels,
+    channel: formStep.outputs.fields.channel,
+    icon: formStep.outputs.fields.icon,
+    username: formStep.outputs.fields.username,
+  },
+);
 
 // Step 3: Send announcement(s)
 const sendStep = CreateAnnouncementWorkflow.addStep(
-  prepareSendAnnouncementFunction,
+  PrepareSendAnnouncementFunctionDefinition,
   {
     message: draftStep.outputs.message,
     channels: formStep.outputs.fields.channels,
@@ -101,7 +104,7 @@ const sendStep = CreateAnnouncementWorkflow.addStep(
 );
 
 // Step 4: Post message summary of announcement
-CreateAnnouncementWorkflow.addStep(PostSummaryFunction, {
+CreateAnnouncementWorkflow.addStep(PostSummaryFunctionDefinition, {
   announcements: sendStep.outputs.announcements,
   channel: formStep.outputs.fields.channel,
   message_ts: draftStep.outputs.message_ts,


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

Chatted with @misscoded and @e-zim a bit today about how we can make it clearer which is the function definition and which is the SlackFunction. Proposing some changes to each of the 3 functions definitions to make it explicit. 

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
