### PR TITLE
Add documentation about datastores in use

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ https://user-images.githubusercontent.com/55667998/211395878-8b261c76-ba7d-4d3f-
 - [Running Your Project Locally](#running-your-project-locally)
 - [Usage](#usage)
   - [Notes](#notes)
+- [Datastores](#datastores)
 - [Testing](#testing)
 - [Deploying Your App](#deploying-your-app)
   - [Viewing Activity Logs](#viewing-activity-logs)
@@ -155,6 +156,13 @@ links) will be posted to the thread.
   [posting has been restricted](https://slack.com/help/articles/360004635551)
   (`restricted_action` error). Give your app explicit permission to post using
   the channel settings if necessary.
+
+### Datastores
+This app uses two datastores: for `announcements` and for `drafts`.
+
+Definition files for these can be found in `datastores/`.
+To use a datastore, an app needs to have `datastore:write`/`datastore:read` scopes,
+which you can see are present in this app's `manifest.ts` file. 
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -158,11 +158,12 @@ links) will be posted to the thread.
   the channel settings if necessary.
 
 ### Datastores
+
 This app uses two datastores: for `announcements` and for `drafts`.
 
-Definition files for these can be found in `datastores/`.
-To use a datastore, an app needs to have `datastore:write`/`datastore:read` scopes,
-which you can see are present in this app's `manifest.ts` file. 
+Definition files for these can be found in `datastores/`. To use a datastore, an
+app needs to have `datastore:write`/`datastore:read` scopes, which are present
+in this app's `manifest.ts` file.
 
 ## Testing
 


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary
Adds some additional documentation about the two datastores in use. 

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
