### PR TITLE
Update draft record using apps.datastore.update

### DIFF
--- a/functions/create_draft/handler.ts
+++ b/functions/create_draft/handler.ts
@@ -82,7 +82,7 @@ export default SlackFunction(
     }
 
     // 3. Update the draft record with the successful sent drafts timestamp
-    const putResp2 = await client.apps.datastore.put<
+    const putResp2 = await client.apps.datastore.update<
       typeof DraftDatastore.definition
     >({
       datastore: DraftDatastore.name,

--- a/functions/create_draft/handler_test.ts
+++ b/functions/create_draft/handler_test.ts
@@ -37,6 +37,15 @@ Deno.test("successfully posts an announcement draft and returns completed:false"
     );
   });
 
+  mf.mock("POST@/api/apps.datastore.update", () => {
+    return new Response(
+      `{"ok": true}`,
+      {
+        status: 200,
+      },
+    );
+  });
+
   // successful chat.postMessage
   mf.mock("POST@/api/chat.postMessage", () => {
     return new Response(


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR fixes Issue #14 and updates `handler.ts` to use `apps.datastore.update` when it needs to update the Draft record in the Datastore. It currently uses `apps.datastore.put` but the behaviour of 'apps.datastore.put' was changed on April 6, 2023 to fully replace an item if it exists. This causes a Draft record to be created with just an `id` and a `message_ts`, leading to the following error when you try to send the announcement.
```
Error completing function {
ok: false,
error: "parameter_validation_failed",
error_messages: [ "Missing value for parameter `message`" ]
}
```

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
