### PR TITLE
Remove no longer needed `@ts-ignore` directives, use trigger enumerations

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,5 +1,17 @@
 {
+  "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
+  "fmt": {
+    "files": {
+      "include": ["README.md", "datastores", "functions", "manifest.ts", "triggers", "workflows"]
+    }
+  },
   "importMap": "import_map.json",
+  "lint": {
+    "files": {
+      "include": ["datastores", "functions", "manifest.ts", "triggers", "workflows"]
+    }
+  },
+  "lock": false,
   "tasks": {
     "test": "deno fmt --check && deno lint && deno test --allow-read --allow-none"
   }

--- a/functions/send_announcement/handler.ts
+++ b/functions/send_announcement/handler.ts
@@ -57,7 +57,6 @@ export default SlackFunction(
         typeof DraftDatastore.definition
       >({
         datastore: DraftDatastore.name,
-        // @ts-ignore expected fix in future release - otherwise missing non-required items throw type error
         item: {
           id: inputs.draft_id,
           status: DraftStatus.Sent,

--- a/functions/send_announcement/handler_test.ts
+++ b/functions/send_announcement/handler_test.ts
@@ -85,7 +85,6 @@ Deno.test("run send announcement fn and return outputs", async () => {
   const { outputs } = await sendAnnouncement(createContext({ inputs }));
   await assertEquals(
     outputs?.announcements,
-    // @ts-ignore 'error' property not required in fn output
     [{
       channel_id: "C12345678",
       success: true,

--- a/triggers/create_announcement.ts
+++ b/triggers/create_announcement.ts
@@ -1,4 +1,5 @@
 import { Trigger } from "deno-slack-sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
 import CreateAnnouncementWorkflow from "../workflows/create_announcement.ts";
 
 /**
@@ -9,17 +10,17 @@ import CreateAnnouncementWorkflow from "../workflows/create_announcement.ts";
 const trigger: Trigger<
   typeof CreateAnnouncementWorkflow.definition
 > = {
-  type: "shortcut",
+  type: TriggerTypes.Shortcut,
   name: "Create an announcement",
   description:
     "Create and send an announcement to one or more channels in your workspace.",
-  workflow: "#/workflows/create_announcement",
+  workflow: `#/workflows/${CreateAnnouncementWorkflow.definition.callback_id}`,
   inputs: {
     created_by: {
-      value: "{{data.user_id}}",
+      value: TriggerContextData.Shortcut.user_id,
     },
     interactivity: {
-      value: "{{data.interactivity}}",
+      value: TriggerContextData.Shortcut.interactivity,
     },
   },
 };


### PR DESCRIPTION
Removing the ts-ignore directives fixes #8.
Use trigger data and type enumerations in trigger definition. Don't hardcode workflow callback id in trigger definition.
