### PR TITLE
Add discard option

### DIFF
--- a/functions/create_draft/blocks.ts
+++ b/functions/create_draft/blocks.ts
@@ -57,6 +57,13 @@ export const buildDraftBlocks = (
               },
               "value": "edit_message_overflow",
             },
+            {
+              "text": {
+                "type": "plain_text",
+                "text": "Discard message",
+              },
+              "value": "discard_message_overflow",
+            },
           ],
           "action_id": "preview_overflow",
         },

--- a/functions/create_draft/blocks.ts
+++ b/functions/create_draft/blocks.ts
@@ -60,7 +60,7 @@ export const buildDraftBlocks = (
             {
               "text": {
                 "type": "plain_text",
-                "text": "Discard message",
+                "text": "Discard the draft message",
               },
               "value": "discard_message_overflow",
             },

--- a/functions/create_draft/interactivity_handler.ts
+++ b/functions/create_draft/interactivity_handler.ts
@@ -88,16 +88,11 @@ export const openDraftEditView: BlockActionHandler<
         id: id,
       });
 
-      // If the DELETE datastore record operation fails, log the error and complete the function with an error
+      // If the DELETE datastore record operation fails, throw an error
       if (!deleteResp.ok) {
         const deleteDraftErrorMsg =
           `Error deleting draft with id ${id}. Contact the app maintainers with the following - (Error detail: ${deleteResp.error})`;
-        console.error(deleteDraftErrorMsg);
-
-        await client.functions.completeError({
-          function_execution_id: body.function_data.execution_id,
-          error: deleteDraftErrorMsg,
-        });
+        throw new Error(deleteDraftErrorMsg);
       }
 
       // If message_ts isn't empty, Delete the draft message from the Draft Channel
@@ -107,13 +102,14 @@ export const openDraftEditView: BlockActionHandler<
           ts: message_ts,
         });
 
-        // If the DELETE message operation fails, log the error
+        // If the DELETE message operation fails, throw an error
         if (!updateResp.ok) {
           const updateDraftPreviewErrorMsg =
             `Error deleting the draft message: ${message_ts} in channel ${inputs.channel}. Contact the app maintainers with the following - (Error detail: ${updateResp.error})`;
-          console.error(updateDraftPreviewErrorMsg);
+          throw new Error(updateDraftPreviewErrorMsg);
         }
       }
+      // If the DELETE datastore record or Slack Message operations fail, log the error and complete the function with an error
     } catch (error) {
       console.error(error);
 

--- a/functions/create_draft/interactivity_handler.ts
+++ b/functions/create_draft/interactivity_handler.ts
@@ -24,7 +24,7 @@ import DraftDatastore from "../../datastores/drafts.ts";
 export const openDraftEditView: BlockActionHandler<
   typeof CreateDraftFunction.definition
 > = async ({ body, action, client, inputs }) => {
-  // If the user selects to edit the message
+  // If the user selects to edit the draft message
   if (action.selected_option.value == "edit_message_overflow") {
     const id = action.block_id;
 
@@ -74,12 +74,12 @@ export const openDraftEditView: BlockActionHandler<
       });
     }
   }
-  // If the user selects to discard the message
+  // If the user selects to discard the draft message
   if (action.selected_option.value == "discard_message_overflow") {
     const id = action.block_id;
     const thread_ts = body.message?.ts || "";
 
-    // Delete the draft message from the Channel
+    // Delete the draft message from the Draft Channel
     const updateResp = await client.chat.delete({
       channel: inputs.channel,
       ts: thread_ts,
@@ -87,11 +87,11 @@ export const openDraftEditView: BlockActionHandler<
 
     if (!updateResp.ok) {
       const updateDraftPreviewErrorMsg =
-        `Error Deleting the message: ${thread_ts} in channel ${inputs.channel}. Contact the app maintainers with the following - (Error detail: ${updateResp.error})`;
+        `Error deleting the draft message: ${thread_ts} in channel ${inputs.channel}. Contact the app maintainers with the following - (Error detail: ${updateResp.error})`;
       console.log(updateDraftPreviewErrorMsg);
     }
 
-    // Delete the draft from the drafts Datstore
+    // Delete the draft from the 'drafts' Datstore
     const deleteResp = await client.apps.datastore.delete({
       datastore: DraftDatastore.name,
       id: id,


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

The goal of this PR is to add a "Discard" option to the Draft Message overflow menu, giving the user the option to quickly Delete the Draft if it's not needed.  The added logic in `create_draft/interactivity_handler.ts` will Delete the message from the Draft Slack Channel and also delete the respective record from the `drafts.ts` Datastore.

![image](https://github.com/slack-samples/deno-announcement-bot/assets/93598341/f7d95388-fc01-480b-80a5-5d3b620d696e)

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
