### PR TITLE
chore: add sample maintainers to the github code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Salesforce Open Source project configuration
+# Learn more: https://github.com/salesforce/oss-template
+#ECCN:Open Source
+#GUSINFO:Open Source,Open Source Workflow
+
+# Code owners are the default owners for everything in
+# this repository. The owners listed below will be requested for
+# review when a pull request is opened.
+# To set code owner(s), replace the team below with either
+# their GitHub username(s) or a GitHub team.
+* @slack-samples/maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-404: Not Found#ECCN:Open Source


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [x] Bug fix
- [x] Documentation

### Summary

This PR moves the `CODEOWNERS` file to the ".github" directory and adds the @slack-samples/maintainers team as a required reviewer for changes 👾 

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)

