### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/datastores/announcements.ts
+++ b/datastores/announcements.ts
@@ -1,4 +1,4 @@
-import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineDatastore, Schema } from "@slack/sdk";
 
 /**
  * Datastores are a Slack-hosted location to store

--- a/datastores/drafts.ts
+++ b/datastores/drafts.ts
@@ -1,4 +1,4 @@
-import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineDatastore, Schema } from "@slack/sdk";
 
 /**
  * Datastores are a Slack-hosted location to store

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,7 +31,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
     "@slack/sdk/functions/interactivity/types": "https://raw.githubusercontent.com/slackapi/deno-slack-sdk/main/src/functions/interactivity/types.ts",
     "@slack/types": "npm:@slack/types@^2.18.0",
     "@std/testing": "jsr:@std/testing@^1.0.16",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,9 +30,10 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk/functions/interactivity/types": "https://raw.githubusercontent.com/slackapi/deno-slack-sdk/main/src/functions/interactivity/types.ts",
     "@slack/types": "npm:@slack/types@^2.18.0",
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
     "@std/testing": "jsr:@std/testing@^1.0.16",
     "@std/assert": "jsr:@std/assert@^1.0.15"
   }

--- a/functions/create_draft/definition.ts
+++ b/functions/create_draft/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
 
 export const CREATE_DRAFT_FUNCTION_CALLBACK_ID = "create_draft";
 /**

--- a/functions/create_draft/handler.ts
+++ b/functions/create_draft/handler.ts
@@ -1,4 +1,4 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
+import { SlackFunction } from "@slack/sdk";
 
 import { CreateDraftFunctionDefinition } from "./definition.ts";
 import { buildDraftBlocks } from "./blocks.ts";

--- a/functions/create_draft/handler_test.ts
+++ b/functions/create_draft/handler_test.ts
@@ -1,4 +1,4 @@
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals, assertExists, assertFalse } from "@std/assert";
 
 import createDraft from "./handler.ts";

--- a/functions/create_draft/interactivity_handler.ts
+++ b/functions/create_draft/interactivity_handler.ts
@@ -1,7 +1,7 @@
 import type {
   BlockActionHandler,
   ViewSubmissionHandler,
-} from "deno-slack-sdk/functions/interactivity/types.ts";
+} from "@slack/sdk/functions/interactivity/types";
 
 import type { CreateDraftFunctionDefinition as CreateDraftFunction } from "./definition.ts";
 import {

--- a/functions/post_summary/definition.ts
+++ b/functions/post_summary/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
 import { AnnouncementCustomType } from "./types.ts";
 
 export const POST_ANNOUNCEMENT_FUNCTION_CALLBACK_ID = "post_summary";

--- a/functions/post_summary/handler.ts
+++ b/functions/post_summary/handler.ts
@@ -1,4 +1,4 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
+import { SlackFunction } from "@slack/sdk";
 
 import { buildSummaryBlocks } from "./blocks.ts";
 import { PostSummaryFunctionDefinition } from "./definition.ts";

--- a/functions/post_summary/handler_test.ts
+++ b/functions/post_summary/handler_test.ts
@@ -1,4 +1,4 @@
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { stub } from "@std/testing/mock";
 

--- a/functions/post_summary/types.ts
+++ b/functions/post_summary/types.ts
@@ -1,4 +1,4 @@
-import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineType, Schema } from "@slack/sdk";
 
 /**
  * This is a Slack Custom type for an Announcement

--- a/functions/send_announcement/definition.ts
+++ b/functions/send_announcement/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
 import { AnnouncementCustomType } from "../post_summary/types.ts";
 
 export const SEND_ANNOUNCEMENT_FUNCTION_CALLBACK_ID = "send_announcement";

--- a/functions/send_announcement/handler.ts
+++ b/functions/send_announcement/handler.ts
@@ -1,5 +1,5 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
-import type { SlackAPIClient } from "deno-slack-sdk/types.ts";
+import { SlackFunction } from "@slack/sdk";
+import type { SlackAPIClient } from "@slack/sdk/types.ts";
 
 import { PrepareSendAnnouncementFunctionDefinition } from "./definition.ts";
 import { buildAnnouncementBlocks, buildSentBlocks } from "./blocks.ts";

--- a/functions/send_announcement/handler_test.ts
+++ b/functions/send_announcement/handler_test.ts
@@ -1,4 +1,4 @@
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals } from "@std/assert";
 
 import sendAnnouncement from "./handler.ts";

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 import AnnouncementDatastore from "./datastores/announcements.ts";
 import DraftDatastore from "./datastores/drafts.ts";
 import { AnnouncementCustomType } from "./functions/post_summary/types.ts";

--- a/triggers/create_announcement.ts
+++ b/triggers/create_announcement.ts
@@ -1,5 +1,5 @@
-import type { Trigger } from "deno-slack-sdk/types.ts";
-import { TriggerContextData, TriggerTypes } from "deno-slack-api/mod.ts";
+import type { Trigger } from "@slack/sdk/types.ts";
+import { TriggerContextData, TriggerTypes } from "@slack/api";
 import CreateAnnouncementWorkflow from "../workflows/create_announcement.ts";
 
 /**

--- a/workflows/create_announcement.ts
+++ b/workflows/create_announcement.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { CreateDraftFunctionDefinition } from "../functions/create_draft/definition.ts";
 import { PostSummaryFunctionDefinition } from "../functions/post_summary/definition.ts";
 import { PrepareSendAnnouncementFunctionDefinition } from "../functions/send_announcement/definition.ts";


### PR DESCRIPTION
### Type of change <!-- place an x in the [ ] that applies -->

- [x] Dependency update

### Summary

Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

### Requirements <!-- place an x in each [ ] that applies -->

- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
